### PR TITLE
Add 0x4A6F as trusted user

### DIFF
--- a/keys/0x4A6F
+++ b/keys/0x4A6F
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFuUdiPdq7neZjTSRoc4PuRg8a6M/JBaJ8fjQxPH6uUT 0x4A6F@darwin-build-box

--- a/users.nix
+++ b/users.nix
@@ -18,6 +18,11 @@ let
       trusted = true;
       uid = 504;
     }
+    {
+      name = "0x4A6F";
+      trusted = true;
+      uid = 505;
+    }
   ];
 in
 {


### PR DESCRIPTION
I have no access to aarch64-darwin or x84_x64-darwin and would like to build/debug on my own and not ping `darwin-maintainers`.