### PR TITLE
add fab as trusted user

### DIFF
--- a/keys/fab
+++ b/keys/fab
@@ -1,0 +1,2 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKjD9rcdx5Py8hQdIhRku1MfO6P7WFpZi+VJZspjj/2 Darwin remote builder 1
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINsRtI+bY95/AJBAaKnWvW/EwG4qs8cFn5bSI+rC78lQ Darwin remote builder 2

--- a/users.nix
+++ b/users.nix
@@ -68,6 +68,11 @@ let
       trusted = true;
       uid = 514;
     }
+    {
+      name = "fab";
+      trusted = true;
+      uid = 515;
+    }
   ];
 in
 {


### PR DESCRIPTION
Would be helpful for the whole Python ecosystem and a bunch of security tools which are primarily Go- or Rust-based. 