### PR TITLE
users.nix: Add toonn as trusted user

### DIFF
--- a/keys/toonn
+++ b/keys/toonn
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPGvIn51XMn1DXred/QGQWBFF6/RwE8cG2dgyrOsXqnT toonn@darwin-build-box

--- a/users.nix
+++ b/users.nix
@@ -78,6 +78,11 @@ let
       trusted = true;
       uid = 516;
     }
+    {
+      name = "toonn";
+      trusted = true;
+      uid = 542;
+    }
   ];
 in
 {


### PR DESCRIPTION
I don't currently have access to aarch64-darwin hardware. This would help test bigger changes across both Darwin architectures.

I skipped a uid because both open PRs already use 515. Though I guess it won't help much with merge conflict due to everyone adding to the end of the list anyway.