### PR TITLE
README: Actually list the pubkey fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ $ sudo su
 # ssh your-user-name@darwin-build-box.winter.cafe -i /root/a-private-key
 ```
 
-The fingerprint should always be:
+The public key and fingerprint should always be:
 
 ```
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB0io9E0eXiDIEHvsibXOxOPveSjUPIr1RnNKbUkw3fD
+Fingerprint: SHA256:9YrbQYYrKN/2GKwFgJz0+fpSbaGe1lJuYFQyPMVdwCY
 ```
 
 ***If it is not, please open an issue!***


### PR DESCRIPTION
The README specified what the fingerprint of the public key should be but actually listed the key instead of its fingerprint.

I copied the key and generated the fingerprint using the following command. This should be easily reproducible.

```
> ssh-keygen -l -f darwin-build-box.pub
256 SHA256:9YrbQYYrKN/2GKwFgJz0+fpSbaGe1lJuYFQyPMVdwCY no comment (ED25519)
```

I left the actual public key in the README because there's no harm in doing so but in principle it might not be necessary.